### PR TITLE
Added border-radius to the CALCULATE button on the instructions page

### DIFF
--- a/lib/screens/instructions.dart
+++ b/lib/screens/instructions.dart
@@ -86,13 +86,19 @@ class Instructions extends StatelessWidget {
                   ),
                 );
               },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.red,
+              style: ButtonStyle(
+                  backgroundColor: MaterialStateProperty.all(Colors.red),
+                shape: MaterialStateProperty.all(
+                  RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  )
+                )
               ),
               child: Padding(
                 padding: const EdgeInsets.all(10.0),
                 child: BorderedText(
                   strokeWidth: 2.0,
+
                   strokeColor: Colors.yellowAccent,
                   child: const Text(
                     'CALCULATE',


### PR DESCRIPTION
Fixes: #7 
Added border radius to calculate button on Instructions page
using Button Style and then setting border radius inside RoundedRectangleBorder

screenshot of result 
![bordradius](https://user-images.githubusercontent.com/119875859/216838822-e78bda8f-61a8-4898-9bc8-ba0dc15c75ba.png)

