### PR TITLE
Alligned the app bar title to center

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -46,6 +46,7 @@ class _HomePageState extends State<HomePage> {
             fontSize: 30,
           ),
         ),
+        centerTitle: true,
       ),
       body: GestureDetector(
         child: Column(


### PR DESCRIPTION
Fixes: #8 

Alligned Center the app bar title i.e. IT'S MONEY on the home page and results page using centerTitle : true

screenshot of output
![center](https://user-images.githubusercontent.com/119875859/216840637-b4f14c21-a8f2-444b-9557-1e1496c16376.png)
