### PR TITLE
Added elevation to the round icon button on the home page. 

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -185,33 +185,40 @@ class _HomePageState extends State<HomePage> {
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            RoundIconButton(
-                              child: const Icon(
-                                Icons.add,
-                                color: Colors.black,
-                                size: 30,
+                            ElevatedButton(
+                                child: const Icon(
+                                    Icons.add,
+                                  color: Colors.black,
+                                  size: 30,
+                                ),
+                              style: ElevatedButton.styleFrom(
+                                primary: Colors.orangeAccent,
+                                shape: const CircleBorder(),
+                                fixedSize: const Size(55, 55)
                               ),
-                              iconColor: Colors.orangeAccent,
-                              parameter: hours,
-                              add: true,
+
                               onPressed: () {
-                                setState(() {
-                                  hours < 10 ? hours++ : hours;
-                                });
+                                  setState(() {
+                                    hours < 10 ? hours++ : hours;
+                                  });
                               },
                             ),
+
                             const SizedBox(
                               width: 10,
                             ),
-                            RoundIconButton(
+                            ElevatedButton(
                               child: const Icon(
                                 Icons.remove,
                                 color: Colors.black,
                                 size: 30,
                               ),
-                              iconColor: Colors.orangeAccent,
-                              parameter: hours,
-                              add: false,
+                              style: ElevatedButton.styleFrom(
+                                  primary: Colors.orangeAccent,
+                                  shape: const CircleBorder(),
+                                  fixedSize: const Size(55, 55)
+                              ),
+
                               onPressed: () {
                                 setState(() {
                                   hours > 0 ? hours-- : hours;
@@ -249,36 +256,42 @@ class _HomePageState extends State<HomePage> {
                         Row(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: [
-                            RoundIconButton(
+                            ElevatedButton(
                               child: const Icon(
                                 Icons.add,
                                 color: Colors.black,
-                                size: 35,
+                                size: 30,
                               ),
-                              iconColor: Colors.orangeAccent,
-                              parameter: experience,
-                              add: true,
+                              style: ElevatedButton.styleFrom(
+                                  primary: Colors.orangeAccent,
+                                  shape: const CircleBorder(),
+                                  fixedSize: const Size(55, 55)
+                              ),
+
                               onPressed: () {
                                 setState(() {
-                                  experience < 10 ? experience++ : experience;
+                                  hours < 10 ? experience++ : experience;
                                 });
                               },
                             ),
                             const SizedBox(
                               width: 10,
                             ),
-                            RoundIconButton(
+                            ElevatedButton(
                               child: const Icon(
                                 Icons.remove,
                                 color: Colors.black,
-                                size: 35,
+                                size: 30,
                               ),
-                              iconColor: Colors.orangeAccent,
-                              parameter: experience,
-                              add: false,
+                              style: ElevatedButton.styleFrom(
+                                  primary: Colors.orangeAccent,
+                                  shape: const CircleBorder(),
+                                  fixedSize: const Size(55, 55)
+                              ),
+
                               onPressed: () {
                                 setState(() {
-                                  experience > 0 ? experience-- : experience;
+                                  hours > 0 ? experience-- : experience;
                                 });
                               },
                             ),


### PR DESCRIPTION
Fixes: #12 
Added elevation to the round icon button on the home page ,These Buttons are used in the HOURS PER DAY and EXPERIENCE money cards.
By using ElevatedButton widget instead of RoundIconButton.
And the used styleForm to give color and shape of button 
and onPressed to add the functioning of the button.

Output screenshot:
![elevatedb](https://user-images.githubusercontent.com/119875859/216901170-ff97f890-e29a-42e2-85d1-e076d558151b.png)

