### PR TITLE
Alligned center the Your Results

### DIFF
--- a/lib/screens/results_page.dart
+++ b/lib/screens/results_page.dart
@@ -36,11 +36,19 @@ class ResultsPage extends StatelessWidget {
           children: [
             Expanded(
               child: Container(
-                padding: const EdgeInsets.all(33.0),
-                alignment: Alignment.bottomLeft,
+                padding: const EdgeInsets.all(15.0),
+                alignment: Alignment.center,
                 child: const Text(
                   'YOUR RESULTS',
-                  style: titleTextStyle,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    letterSpacing: 1.5,
+                    color: Colors.black,
+                    fontSize: 40,
+                    fontFamily: 'MinecraftTen',
+                    // foreground: Paint()
+                    //   ..strokeWidth = 2,
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Fixes: #13 
aligned center using alignment:textalign.center and stroke using strokewidth =2.
screenshot:
![centered](https://user-images.githubusercontent.com/119875859/217023322-8d791ff8-dd27-4a3b-8786-9b90f3f30d5f.png)
